### PR TITLE
Pin nightly Rust

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,8 +49,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
-      - run: rustup override set nightly
-      - run: rustup component add rust-src --toolchain nightly
       - run: .github/wasm.py -o $GITHUB_STEP_SUMMARY
       - uses: actions/upload-artifact@v4
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 Be sure to have these tools installed:
 
 - [GitHub CLI][]
-- [Rust][] nightly with the [`rust-src` component][rust-src]
+- [Rust][]
 - [uv][]
 
 ## Setup
@@ -43,5 +43,4 @@ To make a new release:
 
 [github cli]: https://cli.github.com/
 [rust]: https://www.rust-lang.org/tools/install
-[rust-src]: https://rust-lang.github.io/rustup/concepts/components.html
 [uv]: https://docs.astral.sh/uv

--- a/crates/floretta/src/forward.rs
+++ b/crates/floretta/src/forward.rs
@@ -170,7 +170,7 @@ impl Func {
         self.local_indices[u32_to_usize(index)]
     }
 
-    fn instructions(&mut self) -> InstructionSink {
+    fn instructions(&mut self) -> InstructionSink<'_> {
         self.body.instructions()
     }
 }

--- a/crates/floretta/src/reverse.rs
+++ b/crates/floretta/src/reverse.rs
@@ -1805,7 +1805,7 @@ impl ReverseReverseFunction {
         self.body[n..].reverse();
     }
 
-    fn instructions(&mut self) -> InstructionSink {
+    fn instructions(&mut self) -> InstructionSink<'_> {
         InstructionSink::new(&mut self.body)
     }
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,26 +1,5 @@
 {
   "nodes": {
-    "fenix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src"
-      },
-      "locked": {
-        "lastModified": 1742452566,
-        "narHash": "sha256-sVuLDQ2UIWfXUBbctzrZrXM2X05YjX08K7XHMztt36E=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "7d9ba794daf5e8cc7ee728859bc688d8e26d5f06",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "fenix",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -41,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744096231,
-        "narHash": "sha256-kUfx3FKU1Etnua3EaKvpeuXs7zoFiAcli1gBwkPvGSs=",
+        "lastModified": 1758701979,
+        "narHash": "sha256-c7DUti3XM1aga8oVgaPnrVmEeCFtN9PaBxyNuqx8jPc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b2b0718004cc9a5bca610326de0a82e6ea75920b",
+        "rev": "e2642aa7d5a15eae586932a56f4294934f959c14",
         "type": "github"
       },
       "original": {
@@ -57,25 +36,28 @@
     },
     "root": {
       "inputs": {
-        "fenix": "fenix",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
       }
     },
-    "rust-analyzer-src": {
-      "flake": false,
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1742296961,
-        "narHash": "sha256-gCpvEQOrugHWLimD1wTFOJHagnSEP6VYBDspq96Idu0=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "15d87419f1a123d8f888d608129c3ce3ff8f13d4",
+        "lastModified": 1758767687,
+        "narHash": "sha256-znUulOqcL/Kkdr7CkyIi8Z1pTGXpi54Xg2FmlyJmv4A=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "b8bcc09d4f627f4e325408f6e7a85c3ac31f0eeb",
         "type": "github"
       },
       "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,8 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    fenix = {
-      url = "github:nix-community/fenix";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
@@ -12,27 +12,29 @@
       self,
       nixpkgs,
       flake-utils,
-      fenix,
+      rust-overlay,
     }:
     flake-utils.lib.eachDefaultSystem (
       system:
       let
-        pkgs = import nixpkgs { inherit system; };
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ (import rust-overlay) ];
+        };
       in
       {
-        devShell =
-          with pkgs;
-          mkShell {
-            buildInputs = [
-              gh
-              nixfmt-rfc-style
-              nodejs
-              uv
-              wasm-tools
-
-              (fenix.packages.${system}.latest.toolchain)
-            ];
-          };
+        devShell = pkgs.mkShell {
+          buildInputs = [
+            pkgs.gh
+            pkgs.nixfmt-rfc-style
+            pkgs.nodejs
+            pkgs.uv
+            pkgs.wasm-tools
+            (pkgs.rust-bin.selectLatestNightlyWith (
+              toolchain: toolchain.default.override { extensions = [ "rust-src" ]; }
+            ))
+          ];
+        };
       }
     );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -30,9 +30,7 @@
             pkgs.nodejs
             pkgs.uv
             pkgs.wasm-tools
-            (pkgs.rust-bin.selectLatestNightlyWith (
-              toolchain: toolchain.default.override { extensions = [ "rust-src" ]; }
-            ))
+            (pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml)
           ];
         };
       }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly-2025-09-23"
+components = ["rust-src"]
+profile = "default"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,3 +2,4 @@
 channel = "nightly-2025-09-23"
 components = ["rust-src"]
 profile = "default"
+targets = ["x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl"]


### PR DESCRIPTION
Rust nightly 2025-09-24 and beyond break our `.github/wasm.py` script, so for now this PR fixes the issue by pinning the Rust nightly version in a `rust-toolchain.toml` file. Using this with [fenix](https://github.com/nix-community/fenix) would require manually setting a `sha256` hash in `flake.nix`, so this PR switches to [rust-overlay](https://github.com/oxalica/rust-overlay) which has those hashes precomputed.